### PR TITLE
feat: implement command alias backend

### DIFF
--- a/src/core/bot.js
+++ b/src/core/bot.js
@@ -87,6 +87,7 @@ function getCommand (message, prefix) {
 
 const getCommandArgs = message => message.split(' ').slice(1)
 const getCommandArgString = message => getCommandArgs(message).join(' ')
+const getCommandSubArgString = message => getCommandArgs(message).slice(1).join(' ')
 
 function setupListeners (ctx, bot, prefix) {
   log.trace('registering chat listeners')
@@ -138,6 +139,7 @@ function buildEvent (ctx, user, message, prefix, whispered) {
     args,
     subcommand: args[0],
     argString: getCommandArgString(message),
+    subArgString: getCommandSubArgString(message),
     isPrevented: false
   }
 

--- a/src/core/bot.js
+++ b/src/core/bot.js
@@ -109,7 +109,8 @@ function dispatcher (ctx, bot, prefix, type) {
         return callHookAndWait('beforeMessage', event).then(() => event)
       })
       .then(event => {
-        if (!event.isPrevented && isCommand(message, prefix)) {
+        if (event.isPrevented) return
+        if (isCommand(message, prefix)) {
           return commandHandler(ctx, event)
         }
       })
@@ -119,6 +120,31 @@ function dispatcher (ctx, bot, prefix, type) {
 function commandHandler (ctx, event) {
   return callHookAndWait('receivedCommand', event)
     .then(() => !event.isPrevented && ctx.runCommand(event))
+    .then(commandFound => commandFound === false && aliasHandler(ctx, event))
+}
+
+function aliasHandler (ctx, event) {
+  return ctx.command.getAlias(event.command)
+    .then(original => {
+      if (!original) return
+      let [command, subcommand, ...rest] = original.split(' ')
+      if (!ctx.command.exists(command)) return
+
+      let args = [subcommand, ...rest, ...event.args]
+      let argString = args.join(' ')
+      let subArgs = [...rest, ...event.args]
+      Object.assign(event, {
+        command,
+        subcommand,
+        args,
+        argString,
+        subArgs,
+        subArgString: subArgs.join(' '),
+        raw: `${command} ${argString}`
+      })
+
+      return commandHandler(ctx, event)
+    })
 }
 
 function buildEvent (ctx, user, message, prefix, whispered) {

--- a/src/core/index.js
+++ b/src/core/index.js
@@ -72,7 +72,7 @@ module.exports = class Core extends EventEmitter {
     let { command, subcommand } = event
 
     if (!this.command.exists(command)) {
-      return Promise.resolve()
+      return Promise.resolve(false)
     }
 
     let isSubcommand = () => this.command.exists(command, subcommand)

--- a/src/core/index.js
+++ b/src/core/index.js
@@ -78,6 +78,8 @@ module.exports = class Core extends EventEmitter {
     let isSubcommand = () => this.command.exists(command, subcommand)
     if (!event.subcommand || !isSubcommand()) {
       event.subcommand = undefined
+      event.subArgs = undefined
+      event.subArgString = undefined
     }
 
     return callHookAndWait('beforeCommand', event)

--- a/src/core/lib/alias.js
+++ b/src/core/lib/alias.js
@@ -1,7 +1,7 @@
 'use strict'
 
 module.exports = context => {
-  return db.model('alias', { name: String, original: String })
+  return context.db.model('alias', { name: String, original: String })
     .then(() => {
       function addAlias (name, original) {
         let command = String(original).split(' ', 1)[0]
@@ -24,7 +24,7 @@ module.exports = context => {
 
       context.extend({
         command: {
-          addAlias
+          addAlias,
           removeAlias,
           isAlias
         }

--- a/src/core/lib/alias.js
+++ b/src/core/lib/alias.js
@@ -1,0 +1,33 @@
+'use strict'
+
+module.exports = context => {
+  return db.model('alias', { name: String, original: String })
+    .then(() => {
+      function addAlias (name, original) {
+        let command = String(original).split(' ', 1)[0]
+        if (context.command.exists(name)) return false
+        if (!context.command.exists(command)) return false
+
+        return context.db.create('alias', { name, original })
+          .then(count => count === 1)
+      }
+
+      function removeAlias (name) {
+        return context.db.remove('alias', { name })
+          .then(count => count === 1)
+      }
+      
+      function isAlias (name) {
+        return context.db.findOne('alias', { name })
+          .then(alias => alias && alias.original)
+      }
+
+      context.extend({
+        command: {
+          addAlias
+          removeAlias,
+          isAlias
+        }
+      })
+    })
+}

--- a/src/core/lib/alias.js
+++ b/src/core/lib/alias.js
@@ -16,17 +16,16 @@ module.exports = context => {
         return context.db.remove('alias', { name })
           .then(count => count === 1)
       }
-      
-      function isAlias (name) {
-        return context.db.findOne('alias', { name })
-          .then(alias => alias && alias.original)
+
+      function getAlias (name) {
+        return context.db.findOne('alias.original', { name })
       }
 
       context.extend({
         command: {
           addAlias,
           removeAlias,
-          isAlias
+          getAlias
         }
       })
     })

--- a/src/core/lib/weave.js
+++ b/src/core/lib/weave.js
@@ -52,10 +52,6 @@ module.exports = context => {
     return strat(str, replacements)
   }
 
-  context.on('beforeMessage', () => {
-    console.log(plugins)
-  })
-
   weave.core = function (key /*, ...replacements */) {
     let replacements = context.to.array(arguments, 1)
     let keyPath = toPath(key)


### PR DESCRIPTION
The alias will basically be a macro / shortcut, rather than a strict command <-> alias sharing of functionality. So given `!alias pa points add`, the following would be exactly the same:

```
!points add citycide 50
!pa citycide 50
```

Trailing strings will remain as-is, which allows passing through arguments as if the original command was used normally.

There will be no difference in the event object, so modules won't be able to tell the difference between the alias being used vs the original command.